### PR TITLE
Update apiVersion for k8s version > 1.22

### DIFF
--- a/config/static-egressip-rbac.yaml
+++ b/config/static-egressip-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: static-egressip-controller
   namespace: kube-system
@@ -35,7 +35,7 @@ rules:
       - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: static-egressip-controller
 roleRef:


### PR DESCRIPTION
According to kubernetes documentation:

The rbac.authorization.k8s.io/v1beta1 API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.

    Migrate manifests and API clients to use the rbac.authorization.k8s.io/v1 API version, available since v1.8.
    All existing persisted objects are accessible via the new APIs
    No notable changes

With version v1beta1, using kubernetes v1.22, the RBAC creation throws the following message:

resource mapping not found for name: "static-egressip-controller" namespace: "kube-system" from "https://raw.githubusercontent.com/nirmata/kube-static-egress-ip/master/config/static-egressip-rbac.yaml": no matches for kind "ClusterRole" in version "rbac.authorization.k8s.io/v1beta1" ensure CRDs are installed first
resource mapping not found for name: "static-egressip-controller" namespace: "" from "https://raw.githubusercontent.com/nirmata/kube-static-egress-ip/master/config/static-egressip-rbac.yaml": no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1" ensure CRDs are installed first